### PR TITLE
Make add_apache_to_vagrant_group actually add Apache to Vagrant group.

### DIFF
--- a/puppet/manifests/webserver.pp
+++ b/puppet/manifests/webserver.pp
@@ -1,4 +1,3 @@
-
 class webserver {
   import 'apache'
   class {'apache':
@@ -18,9 +17,6 @@ class webserver {
 }
 
 
-class add_apache_to_vagrant_group {
-User<| title == 'apache' |> { groups +> [ "vagrant" ] }
+exec { "add_apache_to_vagrant_group":
+  command => "/usr/sbin/usermod -a -G vagrant apache",
 }
-
-
-


### PR DESCRIPTION
 add_apache_to_vagrant_group doesn't appear to be working for me as is. I replaced it with an  `usermod` call via `exec`. This is working for me.
